### PR TITLE
Further compact dashboard hero layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,17 +63,17 @@
 
     .hero-dashboard {
       background: var(--surface);
-      border-radius: 16px;
+      border-radius: 14px;
       border: 1px solid rgba(14, 31, 53, 0.08);
-      padding: clamp(1rem, 4vw, 1.65rem);
-      box-shadow: 0 12px 24px -18px rgba(13, 34, 78, 0.35);
+      padding: clamp(0.6rem, 2.4vw, 1.1rem);
+      box-shadow: 0 10px 20px -18px rgba(13, 34, 78, 0.35);
       display: flex;
       flex-direction: column;
-      gap: clamp(1rem, 4vw, 1.75rem);
-      width: clamp(280px, 92vw, 900px);
+      gap: clamp(0.55rem, 2.4vw, 1rem);
+      width: clamp(260px, 88vw, 640px);
       margin: 0 auto;
-      background-image: radial-gradient(circle at top left, rgba(11, 87, 208, 0.12), transparent 55%),
-        radial-gradient(circle at bottom right, rgba(15, 157, 88, 0.1), transparent 60%);
+      background-image: radial-gradient(circle at top left, rgba(11, 87, 208, 0.1), transparent 50%),
+        radial-gradient(circle at bottom right, rgba(15, 157, 88, 0.08), transparent 55%);
     }
 
     .dashboard-identity {
@@ -81,11 +81,11 @@
       align-items: center;
       justify-content: flex-start;
       flex-wrap: wrap;
-      gap: clamp(0.85rem, 4vw, 1.75rem);
+      gap: clamp(0.45rem, 2.5vw, 1rem);
     }
 
     .dashboard-identity .dashboard-logo {
-      width: clamp(88px, 22vw, 132px);
+      width: clamp(68px, 18vw, 105px);
       height: auto;
       flex: 0 0 auto;
     }
@@ -93,21 +93,21 @@
     .dashboard-identity-copy {
       display: flex;
       flex-direction: column;
-      gap: 0.35rem;
-      min-width: min(240px, 100%);
+      gap: 0.25rem;
+      min-width: min(220px, 100%);
     }
 
     .dashboard-identity h1 {
       margin: 0;
-      font-size: clamp(1.55rem, 4.8vw, 2.25rem);
+      font-size: clamp(1.4rem, 4.2vw, 2rem);
       font-weight: 600;
     }
 
     .dashboard-identity p {
       margin: 0;
       color: var(--muted);
-      font-size: clamp(1rem, 3.8vw, 1.1rem);
-      max-width: 40rem;
+      font-size: clamp(0.95rem, 3.4vw, 1.02rem);
+      max-width: 34rem;
     }
 
     .hero-dashboard header,
@@ -126,65 +126,65 @@
     .hero-dashboard .dashboard-summary {
       display: flex;
       flex-wrap: wrap;
-      gap: 0.75rem clamp(0.75rem, 3vw, 1.5rem);
-      font-size: clamp(0.95rem, 3.4vw, 1.05rem);
+      gap: 0.4rem clamp(0.4rem, 2vw, 0.85rem);
+      font-size: clamp(0.85rem, 2.6vw, 0.95rem);
     }
 
     .hero-dashboard .dashboard-summary span {
       display: flex;
       align-items: baseline;
-      gap: 0.35rem;
+      gap: 0.25rem;
       color: var(--muted);
     }
 
     .hero-dashboard .dashboard-summary strong {
-      font-size: clamp(1.2rem, 4vw, 1.4rem);
+      font-size: clamp(1.05rem, 3.6vw, 1.28rem);
       color: var(--text);
     }
 
     .dashboard-body {
       display: grid;
-      gap: clamp(1rem, 4vw, 1.5rem);
+      gap: clamp(0.55rem, 2.4vw, 0.95rem);
     }
 
     .dashboard-grid {
       display: grid;
-      gap: clamp(0.75rem, 3vw, 1.25rem);
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: clamp(0.45rem, 2vw, 0.85rem);
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     }
 
     .dashboard-card {
       border: 1px solid rgba(14, 31, 53, 0.06);
-      border-radius: 14px;
-      padding: clamp(0.85rem, 3.5vw, 1.1rem);
+      border-radius: 12px;
+      padding: clamp(0.6rem, 2.4vw, 0.85rem);
       background: var(--surface-alt);
       display: flex;
       flex-direction: column;
-      gap: 0.5rem;
+      gap: 0.3rem;
     }
 
     .dashboard-card h3 {
       margin: 0;
-      font-size: clamp(1.05rem, 3.4vw, 1.25rem);
+      font-size: clamp(0.98rem, 3.1vw, 1.18rem);
       font-weight: 600;
     }
 
     .dashboard-card .metric-group {
       display: flex;
       flex-direction: column;
-      gap: 0.35rem;
+      gap: 0.25rem;
     }
 
     .dashboard-card .metric {
       display: flex;
       flex-direction: column;
-      gap: 0.15rem;
+      gap: 0.05rem;
       color: var(--muted);
-      font-size: clamp(0.85rem, 3vw, 0.95rem);
+      font-size: clamp(0.78rem, 2.5vw, 0.88rem);
     }
 
     .dashboard-card .metric strong {
-      font-size: clamp(1.4rem, 4.8vw, 1.8rem);
+      font-size: clamp(1.25rem, 4.2vw, 1.6rem);
       font-weight: 600;
       color: var(--text);
     }
@@ -197,11 +197,11 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: 0.75rem;
+      gap: 0.45rem;
     }
 
     .dashboard-visual canvas {
-      width: min(220px, 100%);
+      width: min(150px, 100%);
       height: auto;
       aspect-ratio: 1 / 1;
     }
@@ -209,21 +209,21 @@
     .dashboard-legend {
       width: 100%;
       display: grid;
-      gap: 0.5rem;
-      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 0.35rem;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
     }
 
     .legend-item {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      font-size: clamp(0.85rem, 3vw, 0.95rem);
+      gap: 0.35rem;
+      font-size: clamp(0.8rem, 2.6vw, 0.9rem);
       color: var(--muted);
     }
 
     .legend-item .swatch {
-      width: 14px;
-      height: 14px;
+      width: 12px;
+      height: 12px;
       border-radius: 50%;
       display: inline-flex;
     }
@@ -1089,7 +1089,7 @@
       }
 
       .hero-dashboard {
-        width: clamp(360px, 78vw, 960px);
+        width: clamp(340px, 72vw, 820px);
       }
 
       .dashboard-identity {
@@ -1143,7 +1143,6 @@
           </div>
         </div>
         <div class="dashboard-header">
-          <h2>Live request dashboard</h2>
           <div class="dashboard-summary">
             <span>
               <strong data-dashboard-total="all">—</strong>


### PR DESCRIPTION
## Summary
- remove the "Live request dashboard" heading from the hero panel
- tighten spacing and dimensions on the dashboard cards and chart to reduce empty space
- further compact the hero dashboard card by reducing padding, gaps, and typography scale

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dc74026684832e99bc9ea7a1a52b74