### PR TITLE
Hide ETA input on denied supplies requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -2508,7 +2508,9 @@
           const footer = document.createElement('div');
           footer.className = 'request-item-footer';
 
-          if (type === 'supplies') {
+          const showEtaField = type === 'supplies' && shouldShowEtaField(stateKey);
+
+          if (showEtaField) {
             const etaWrapper = document.createElement('label');
             etaWrapper.className = 'eta-field';
 
@@ -2714,6 +2716,13 @@
             handleError(err, 'updateRequestEta', payload);
           })
           .updateRequestStatus(payload);
+      }
+
+      function shouldShowEtaField(status) {
+        const key = typeof status === 'string'
+          ? status.trim().toLowerCase().replace(/\s+/g, '_')
+          : '';
+        return key !== 'denied';
       }
 
       function canEditEtaStatus(status) {


### PR DESCRIPTION
## Summary
- hide the supplies ETA field when the request status is denied
- add a helper to determine when the ETA control should render

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_b_68dc75a69378832ea2c5e55ca1c94c6c