### PR TITLE
Restore dashboard logo and enlarge pie chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,22 @@
       align-items: stretch;
     }
 
+    .hero-dashboard-shell {
+      width: 100%;
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: 1fr;
+      align-items: center;
+      justify-items: center;
+      gap: clamp(0.75rem, 3vw, 1.5rem);
+    }
+
+    .hero-dashboard-logo {
+      width: clamp(150px, 32vw, 210px);
+      max-width: 100%;
+      height: auto;
+    }
+
     .hero-dashboard {
       background: var(--surface);
       border-radius: 14px;
@@ -214,7 +230,7 @@
     }
 
     .dashboard-visual canvas {
-      width: min(140px, 100%);
+      width: min(100%, clamp(200px, 50vw, 280px));
       height: auto;
       aspect-ratio: 1 / 1;
     }
@@ -275,6 +291,23 @@
       .dashboard-visual {
         justify-self: end;
         align-items: flex-end;
+      }
+    }
+
+    @media (min-width: 900px) {
+      .hero-dashboard-shell {
+        grid-template-columns: 1fr auto 1fr;
+        gap: clamp(1rem, 3vw, 2.5rem);
+      }
+
+      .hero-dashboard-shell .hero-dashboard {
+        grid-column: 2;
+        justify-self: center;
+      }
+
+      .hero-dashboard-logo {
+        grid-column: 1;
+        justify-self: end;
       }
     }
 
@@ -1119,12 +1152,21 @@
 <body>
   <header>
     <div class="hero-inner">
-      <section
-        class="hero-dashboard"
-        id="heroDashboard"
-        aria-label="Request activity dashboard"
-        aria-live="polite"
-      >
+      <div class="hero-dashboard-shell">
+        <img
+          class="hero-dashboard-logo"
+          src="https://www.dublincleaners.com/wp-content/uploads/2024/12/Dublin-Logos-stacked.png"
+          alt="Dublin Cleaners logo"
+          loading="lazy"
+          decoding="async"
+          width="180"
+        >
+        <section
+          class="hero-dashboard"
+          id="heroDashboard"
+          aria-label="Request activity dashboard"
+          aria-live="polite"
+        >
         <div class="dashboard-top">
           <div class="dashboard-header">
             <div class="dashboard-header-top">
@@ -1143,7 +1185,7 @@
             </div>
           </div>
           <div class="dashboard-visual">
-            <canvas id="dashboardPie" width="220" height="220" role="img" aria-label="Outstanding requests by type"></canvas>
+            <canvas id="dashboardPie" width="280" height="280" role="img" aria-label="Outstanding requests by type"></canvas>
           </div>
         </div>
         <div class="dashboard-grid">
@@ -1189,6 +1231,7 @@
         </div>
         <p class="dashboard-empty" id="dashboardEmptyMessage" hidden>No requests yet.</p>
       </section>
+      </div>
     </div>
   </header>
   <nav class="tab-nav" aria-label="Request types">


### PR DESCRIPTION
## Summary
- restore the Dublin Cleaners logo alongside the dashboard without shifting the centered card
- adjust hero layout styling to support the new logo placement and responsive spacing
- enlarge the dashboard pie chart canvas so the center labels no longer overlap the chart slices

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dcf3c4cde0832e85c7b47b6a9d54af