### PR TITLE
Reorder supplies approval notices

### DIFF
--- a/index.html
+++ b/index.html
@@ -1314,6 +1314,11 @@
             <button type="submit" id="suppliesSubmitButton">Submit request</button>
             <button type="button" id="suppliesResetButton" class="secondary">Reset</button>
           </div>
+          <aside class="notice-block full-width" role="note" aria-label="Supply request approval process">
+            <h3>Supply request approvals</h3>
+            <p>All supply requests must first be approved by a Manager. Approved orders will be placed once per week, every Monday Morning.</p>
+            <p>If your request is missed, it will roll into the following week’s order. This process helps us stay efficient and keep operations running smoothly.</p>
+          </aside>
           <div
             class="approver-notice"
             data-approver-notice="supplies"
@@ -1321,11 +1326,6 @@
             hidden
           ></div>
         </form>
-        <aside class="notice-block" role="note" aria-label="Supply request approval process">
-          <h3>Supply request approvals</h3>
-          <p>All supply requests must first be approved by a Manager. Approved orders will be placed once per week, every Monday Morning.</p>
-          <p>If your request is missed, it will roll into the following week’s order. This process helps us stay efficient and keep operations running smoothly.</p>
-        </aside>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- move the supplies approval process notice above the approver warning inside the supplies form
- ensure the notice spans the full form width after relocation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dd0c94df58832e8af5402bf4f6da44