### PR TITLE
Remove Full Catalog button from supplies requests card

### DIFF
--- a/index.html
+++ b/index.html
@@ -1397,7 +1397,6 @@
             <span class="card-title">Supplies requests</span>
             <span class="card-subtitle meta">Track order status and approvals in one place.</span>
           </div>
-          <button type="button" id="catalogScrollButton" class="card-header-action">Full Catalog</button>
         </div>
         <div class="card-body">
           <div id="suppliesRequestsList" class="list" role="list"></div>


### PR DESCRIPTION
## Summary
- remove the redundant Full Catalog button from the supplies requests card header so it no longer appears in the dashboard

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dd237e754c832ebaac781edee19f27