### PR TITLE
Remove unsupported theme color meta tag from HtmlOutput

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -72,7 +72,6 @@ function doGet(e) {
   template.bootstrap = buildBootstrapPayload_(email, roles, cid);
   const output = template.evaluate();
   output.setTitle(APP_CONFIG.brand.title);
-  output.addMetaTag("theme-color", "#0b57d0");
   return output;
 }
 


### PR DESCRIPTION
## Summary
- remove the theme-color meta tag injection that Apps Script rejects during web app rendering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e55f6e6968832e80eb48fcdb001128