### PR TITLE
Adjust hero buttons to fit on a single row

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,8 +118,9 @@
 
     .hero-actions {
       display: flex;
-      flex-wrap: wrap;
-      gap: 0.75rem;
+      flex-wrap: nowrap;
+      gap: 0.6rem;
+      align-items: stretch;
     }
 
     .hero-actions button {
@@ -128,8 +129,12 @@
       --button-fg: #fff;
       --button-shadow: rgba(11, 87, 208, 0.65);
       --button-shadow-active: rgba(11, 87, 208, 0.75);
-      font-size: clamp(0.95rem, 3.4vw, 1.1rem);
-      padding-inline: clamp(1.1rem, 4vw, 1.6rem);
+      flex: 1 1 0;
+      min-width: 0;
+      font-size: clamp(0.85rem, 3vw, 1rem);
+      padding: clamp(0.65rem, 2.8vw, 0.9rem) clamp(0.85rem, 3vw, 1.15rem);
+      text-align: center;
+      line-height: 1.35;
       box-shadow: 0 18px 45px -30px var(--button-shadow);
     }
 
@@ -156,6 +161,17 @@
       --button-hover-bg: var(--maintenance-color-strong);
       --button-shadow: rgba(242, 153, 0, 0.45);
       --button-shadow-active: rgba(242, 153, 0, 0.6);
+    }
+
+    @media (max-width: 540px) {
+      .hero-actions {
+        gap: 0.45rem;
+      }
+
+      .hero-actions button {
+        font-size: clamp(0.8rem, 3.8vw, 0.9rem);
+        padding: 0.6rem 0.85rem;
+      }
     }
 
     .hero-stats {
@@ -1505,7 +1521,7 @@
         <div class="hero-actions">
           <button type="button" data-tab-trigger="supplies" class="active">Start a supplies request</button>
           <button type="button" data-tab-trigger="it">Log an IT issue</button>
-          <button type="button" data-tab-trigger="maintenance">Log a maintenance issue</button>
+          <button type="button" data-tab-trigger="maintenance">Maintenance issues</button>
         </div>
         <div class="hero-stats">
           <div class="hero-stat">


### PR DESCRIPTION
## Summary
- compress the hero action buttons so they share width and render on a single line
- restore the original hero button labels while keeping the streamlined layout in place
- add a small-screen tweak so the tighter styling stays readable on phones
- rename the maintenance hero button to "Maintenance issues" per the updated copy direction

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e56d3c0a54832e991486ef806de4fe