### PR TITLE
Adjust scroll offset for hero tab navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2456,10 +2456,21 @@ function renderApproverUnavailable(auth) {
 
       function scrollToTab(type) {
         const anchor = dom.tabAnchors && dom.tabAnchors[type];
-        if (!anchor || typeof anchor.scrollIntoView !== 'function') {
+        if (!anchor || typeof anchor.getBoundingClientRect !== 'function') {
           return;
         }
-        anchor.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+        const nav = document.querySelector('.tab-nav');
+        const navRect = nav && typeof nav.getBoundingClientRect === 'function' ? nav.getBoundingClientRect() : null;
+        const navStyles = nav && typeof window.getComputedStyle === 'function' ? window.getComputedStyle(nav) : null;
+        const navSpacing = navStyles ? parseFloat(navStyles.marginBottom || '0') : 0;
+        const navOffset = navRect ? navRect.height + navSpacing : 0;
+        const extraSpacing = 16;
+
+        const anchorTop = anchor.getBoundingClientRect().top + window.pageYOffset;
+        const targetTop = Math.max(anchorTop - navOffset - extraSpacing, 0);
+
+        window.scrollTo({ top: targetTop, behavior: 'smooth' });
       }
 
       function attachFormHandlers() {


### PR DESCRIPTION
## Summary
- adjust smooth-scroll behavior so hero buttons stop with the tab nav still visible
- account for tab nav height plus spacing when calculating the target scroll position

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e57256d4f8832eb037867d24fded53