### PR TITLE
Tighten dashboard metric cards layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,8 +283,14 @@
 
     .dashboard-grid {
       display: grid;
-      gap: clamp(0.4rem, 2vw, 0.75rem);
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: clamp(0.35rem, 1.8vw, 0.6rem);
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    @media (max-width: 720px) {
+      .dashboard-grid {
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      }
     }
 
     .dashboard-card {
@@ -294,10 +300,10 @@
       --card-outline: rgba(11, 87, 208, 0.22);
       border: 1px solid var(--card-outline);
       border-radius: 12px;
-      padding: clamp(0.55rem, 2vw, 0.8rem);
+      padding: clamp(0.45rem, 1.7vw, 0.7rem);
       background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.78)), var(--card-soft);
       display: grid;
-      gap: 0.35rem;
+      gap: 0.25rem;
       align-content: start;
     }
 
@@ -324,25 +330,25 @@
 
     .dashboard-card h3 {
       margin: 0;
-      font-size: clamp(0.95rem, 3vw, 1.12rem);
+      font-size: clamp(0.92rem, 2.8vw, 1.05rem);
       font-weight: 600;
       color: var(--card-color-strong);
     }
 
     .dashboard-card .metric-group {
       display: grid;
-      gap: 0.35rem;
+      gap: 0.25rem;
     }
 
     .dashboard-card .metric {
       display: grid;
       gap: 0.15rem;
       color: var(--muted);
-      font-size: clamp(0.76rem, 2.3vw, 0.86rem);
+      font-size: clamp(0.72rem, 2.1vw, 0.82rem);
     }
 
     .dashboard-card .metric strong {
-      font-size: clamp(1.1rem, 3.6vw, 1.45rem);
+      font-size: clamp(1.02rem, 3.3vw, 1.28rem);
       font-weight: 600;
       color: var(--text);
     }
@@ -1607,11 +1613,11 @@
               <div class="metric-group">
                 <span class="metric highlight">
                   <strong data-dashboard-outstanding="supplies">—</strong>
-                  Awaiting approval/completion
+                  Open items
                 </span>
                 <span class="metric">
                   <strong data-dashboard-total="supplies">—</strong>
-                  Total requests
+                  Logged total
                 </span>
               </div>
             </article>
@@ -1620,11 +1626,11 @@
               <div class="metric-group">
                 <span class="metric highlight">
                   <strong data-dashboard-outstanding="it">—</strong>
-                  Awaiting approval/completion
+                  Open items
                 </span>
                 <span class="metric">
                   <strong data-dashboard-total="it">—</strong>
-                  Total requests
+                  Logged total
                 </span>
               </div>
             </article>
@@ -1633,11 +1639,11 @@
               <div class="metric-group">
                 <span class="metric highlight">
                   <strong data-dashboard-outstanding="maintenance">—</strong>
-                  Awaiting approval/completion
+                  Open items
                 </span>
                 <span class="metric">
                   <strong data-dashboard-total="maintenance">—</strong>
-                  Total requests
+                  Logged total
                 </span>
               </div>
             </article>


### PR DESCRIPTION
## Summary
- compress the dashboard card grid so supplies, IT, and maintenance metrics stay on one row on wide screens
- shrink metric typography and padding for a denser presentation that still reads well
- shorten metric labels to keep text from wrapping and preserve a tidy layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e57cb62cac832ea4920a7099e5aebd