### PR TITLE
Add supplies denied ratio to dashboard

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -493,10 +493,16 @@ function getDashboardMetrics(request) {
       let completionCount = 0;
       let startMsTotal = 0;
       let startCount = 0;
+      let deniedCount = 0;
+      let approvedCount = 0;
       records.forEach(record => {
         const statusKey = toStatusKey_(record && record.status);
         if (statusKey === 'denied') {
+          deniedCount++;
           return;
+        }
+        if (statusKey === 'approved' || statusKey === 'completed' || statusKey === 'closed') {
+          approvedCount++;
         }
         const openedMs = toTimestampMs_(record && record.ts);
         if (!openedMs) {
@@ -523,7 +529,9 @@ function getDashboardMetrics(request) {
         avgCompletionMs,
         completionCount,
         avgStartMs,
-        startCount
+        startCount,
+        deniedCount,
+        approvedCount
       };
       totalRequests += total;
       outstandingRequests += outstanding;

--- a/index.html
+++ b/index.html
@@ -1956,6 +1956,10 @@
                   <strong data-dashboard-total="supplies">—</strong>
                   Logged total
                 </span>
+                <span class="metric" data-dashboard-denied-ratio-wrapper="supplies">
+                  <strong data-dashboard-denied-ratio="supplies">—</strong>
+                  Denied vs approved ratio
+                </span>
                 <span class="metric" data-dashboard-avg-completion-wrapper="supplies">
                   <strong data-dashboard-avg-completion="supplies">—</strong>
                   Avg completion time
@@ -2549,7 +2553,9 @@
               avgStart: document.querySelector(`[data-dashboard-avg-start="${type}"]`),
               avgStartWrapper: document.querySelector(`[data-dashboard-avg-start-wrapper="${type}"]`),
               avgCompletion: document.querySelector(`[data-dashboard-avg-completion="${type}"]`),
-              avgCompletionWrapper: document.querySelector(`[data-dashboard-avg-completion-wrapper="${type}"]`)
+              avgCompletionWrapper: document.querySelector(`[data-dashboard-avg-completion-wrapper="${type}"]`),
+              deniedRatio: document.querySelector(`[data-dashboard-denied-ratio="${type}"]`),
+              deniedRatioWrapper: document.querySelector(`[data-dashboard-denied-ratio-wrapper="${type}"]`)
             };
             return acc;
           }, {}),
@@ -2641,6 +2647,8 @@
               const completionCount = entry && Number(entry.completionCount);
               const avgStartMs = entry && Number(entry.avgStartMs);
               const startCount = entry && Number(entry.startCount);
+              const deniedCount = entry && Number(entry.deniedCount);
+              const approvedCount = entry && Number(entry.approvedCount);
               metrics[type] = {
                 total: Number.isFinite(total) && total > 0 ? total : 0,
                 outstanding: Number.isFinite(outstanding) && outstanding > 0 ? outstanding : 0,
@@ -2651,6 +2659,12 @@
                 avgStartMs: Number.isFinite(avgStartMs) && avgStartMs > 0 ? avgStartMs : 0,
                 startCount: Number.isFinite(startCount) && startCount > 0
                   ? Math.max(1, Math.round(startCount))
+                  : 0,
+                deniedCount: Number.isFinite(deniedCount) && deniedCount >= 0
+                  ? Math.max(0, Math.round(deniedCount))
+                  : 0,
+                approvedCount: Number.isFinite(approvedCount) && approvedCount >= 0
+                  ? Math.max(0, Math.round(approvedCount))
                   : 0
               };
             });
@@ -2704,8 +2718,11 @@
             avgCompletionMs: 0,
             completionCount: 0,
             avgStartMs: 0,
-            startCount: 0
+            startCount: 0,
+            deniedCount: 0,
+            approvedCount: 0
           };
+          const typeLabel = type === 'it' ? 'IT' : `${type.charAt(0).toUpperCase()}${type.slice(1)}`;
           const totalLabel = loading ? '…' : formatDashboardCount(entry.total);
           const outstandingLabel = loading ? '…' : formatDashboardCount(entry.outstanding);
           const hasCompletionData = !loading && Number(entry.completionCount) > 0;
@@ -2720,12 +2737,44 @@
             : hasStartData
               ? formatDashboardDuration(entry.avgStartMs)
               : '—';
+          const deniedCount = loading ? 0 : Math.max(0, Number(entry.deniedCount) || 0);
+          const approvedCount = loading ? 0 : Math.max(0, Number(entry.approvedCount) || 0);
+          const hasRatioData = !loading && approvedCount > 0;
+          const hasRatioHistory = !loading && (approvedCount > 0 || deniedCount > 0);
+          const ratioLabel = loading
+            ? '…'
+            : hasRatioData
+              ? formatDashboardRatio(deniedCount, approvedCount)
+              : '—';
           if (elements) {
             if (elements.total) {
               elements.total.textContent = totalLabel;
             }
             if (elements.outstanding) {
               elements.outstanding.textContent = outstandingLabel;
+            }
+            if (elements.deniedRatio) {
+              elements.deniedRatio.textContent = ratioLabel;
+            }
+            if (elements.deniedRatioWrapper) {
+              if (loading) {
+                elements.deniedRatioWrapper.dataset.state = 'loading';
+                elements.deniedRatioWrapper.removeAttribute('title');
+              } else if (hasRatioData) {
+                elements.deniedRatioWrapper.dataset.state = 'ready';
+                const deniedLabel = formatDashboardCount(deniedCount);
+                const approvedLabel = formatDashboardCount(approvedCount);
+                elements.deniedRatioWrapper.setAttribute(
+                  'title',
+                  `${deniedLabel} denied vs ${approvedLabel} approved ${typeLabel} requests.`
+                );
+              } else if (hasRatioHistory) {
+                elements.deniedRatioWrapper.dataset.state = 'empty';
+                elements.deniedRatioWrapper.setAttribute('title', `No approved ${typeLabel} requests yet.`);
+              } else {
+                elements.deniedRatioWrapper.dataset.state = 'empty';
+                elements.deniedRatioWrapper.setAttribute('title', `No reviewed ${typeLabel} requests yet.`);
+              }
             }
             if (elements.avgStart) {
               elements.avgStart.textContent = startLabel;
@@ -2940,6 +2989,43 @@
         return `${formatted} ${unit}${plural}`;
       }
 
+      function formatDashboardRatio(denied, approved) {
+        const deniedValue = Number(denied);
+        const approvedValue = Number(approved);
+        const deniedCount = Number.isFinite(deniedValue) ? Math.max(0, Math.round(deniedValue)) : 0;
+        const approvedCount = Number.isFinite(approvedValue) ? Math.max(0, Math.round(approvedValue)) : 0;
+        if (approvedCount === 0 && deniedCount === 0) {
+          return '—';
+        }
+        if (deniedCount === 0 || approvedCount === 0) {
+          return `${formatDashboardCount(deniedCount)} : ${formatDashboardCount(approvedCount)}`;
+        }
+        const divisor = greatestCommonDivisor(deniedCount, approvedCount);
+        const left = deniedCount / divisor;
+        const right = approvedCount / divisor;
+        return `${formatDashboardCount(left)} : ${formatDashboardCount(right)}`;
+      }
+
+      function greatestCommonDivisor(a, b) {
+        let x = Math.abs(Number(a)) || 0;
+        let y = Math.abs(Number(b)) || 0;
+        if (!Number.isFinite(x)) {
+          x = 0;
+        }
+        if (!Number.isFinite(y)) {
+          y = 0;
+        }
+        if (x === 0 && y === 0) {
+          return 1;
+        }
+        while (y !== 0) {
+          const temp = y;
+          y = x % y;
+          x = temp;
+        }
+        return x === 0 ? 1 : x;
+      }
+
       function makeEmptyDashboardMetrics() {
         return REQUEST_KEYS.reduce((acc, type) => {
           acc[type] = {
@@ -2948,7 +3034,9 @@
             avgCompletionMs: 0,
             completionCount: 0,
             avgStartMs: 0,
-            startCount: 0
+            startCount: 0,
+            deniedCount: 0,
+            approvedCount: 0
           };
           return acc;
         }, {});


### PR DESCRIPTION
## Summary
- compute approved and denied counts for each request type in the dashboard metrics response
- render a new Supplies "Denied vs approved ratio" stat with tooltips and formatting helpers
- add ratio formatting utilities and wire the new metric into dashboard state management

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e592ebcd10832e8aff2e763b748186